### PR TITLE
Move index page styles into external stylesheet

### DIFF
--- a/RadioQ10/wwwroot/css/index.css
+++ b/RadioQ10/wwwroot/css/index.css
@@ -1,0 +1,125 @@
+:root {
+    font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+}
+
+body {
+    margin: 24px;
+}
+
+.controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+input[type="text"] {
+    padding: 8px 10px;
+    min-width: 260px;
+}
+
+button {
+    padding: 8px 12px;
+    cursor: pointer;
+}
+
+#player1 {
+    aspect-ratio: 16 / 9;
+    width: 100%;
+}
+
+.small {
+    opacity: .8;
+    font-size: .9rem;
+}
+
+.stack {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+#searchResults {
+    margin-top: 16px;
+}
+
+.video-result {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px;
+    border-bottom: 1px solid #eee;
+    cursor: pointer;
+}
+
+.video-result:hover {
+    background: #f5f5f5;
+}
+
+.video-thumb {
+    width: 120px;
+    height: 68px;
+    object-fit: cover;
+}
+
+.video-title {
+    font-size: 1rem;
+    font-weight: 500;
+}
+
+.queue-section {
+    margin-top: 24px;
+}
+
+.queue-section h2 {
+    margin: 0 0 8px;
+    font-size: 1.2rem;
+}
+
+.queue-meta {
+    font-size: .85rem;
+    color: #555;
+}
+
+.queue-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    border: 1px solid #eee;
+    border-radius: 8px;
+    max-width: 560px;
+}
+
+.queue-item {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    padding: 10px 12px;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.queue-item:last-child {
+    border-bottom: none;
+}
+
+.queue-thumb {
+    width: 64px;
+    height: 36px;
+    object-fit: cover;
+    border-radius: 4px;
+    background: #ddd;
+}
+
+.queue-title {
+    font-weight: 600;
+    line-height: 1.3;
+}
+
+#percent {
+    width: 80px;
+}
+
+#barProgress {
+    accent-color: #2563eb;
+}

--- a/RadioQ10/wwwroot/index.html
+++ b/RadioQ10/wwwroot/index.html
@@ -4,125 +4,7 @@
     <meta charset="utf-8" />
     <title>Reproductor YouTube sincronizado (1 video)</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <style>
-        :root {
-            font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-        }
-
-        body {
-            margin: 24px;
-        }
-
-        .controls {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 12px;
-            align-items: center;
-            margin-bottom: 16px;
-        }
-
-        input[type="text"] {
-            padding: 8px 10px;
-            min-width: 260px;
-        }
-
-        button {
-            padding: 8px 12px;
-            cursor: pointer;
-        }
-
-        #player1 {
-            aspect-ratio: 16/9;
-            width: 100%;
-        }
-
-        .small {
-            opacity: .8;
-            font-size: .9rem;
-        }
-
-        .stack {
-            display: flex;
-            gap: 8px;
-            align-items: center;
-        }
-
-        #searchResults {
-            margin-top: 16px;
-        }
-
-        .video-result {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-            padding: 8px;
-            border-bottom: 1px solid #eee;
-            cursor: pointer;
-        }
-
-            .video-result:hover {
-                background: #f5f5f5;
-            }
-
-        .video-thumb {
-            width: 120px;
-            height: 68px;
-            object-fit: cover;
-        }
-
-        .video-title {
-            font-size: 1rem;
-            font-weight: 500;
-        }
-
-        .queue-section {
-            margin-top: 24px;
-        }
-
-        .queue-section h2 {
-            margin: 0 0 8px;
-            font-size: 1.2rem;
-        }
-
-        .queue-meta {
-            font-size: .85rem;
-            color: #555;
-        }
-
-        .queue-list {
-            list-style: none;
-            padding: 0;
-            margin: 0;
-            border: 1px solid #eee;
-            border-radius: 8px;
-            max-width: 560px;
-        }
-
-        .queue-item {
-            display: flex;
-            gap: 12px;
-            align-items: center;
-            padding: 10px 12px;
-            border-bottom: 1px solid #f0f0f0;
-        }
-
-        .queue-item:last-child {
-            border-bottom: none;
-        }
-
-        .queue-thumb {
-            width: 64px;
-            height: 36px;
-            object-fit: cover;
-            border-radius: 4px;
-            background: #ddd;
-        }
-
-        .queue-title {
-            font-weight: 600;
-            line-height: 1.3;
-        }
-    </style>
+    <link rel="stylesheet" href="css/index.css" />
     <!-- SignalR client -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/7.0.5/signalr.min.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
@@ -144,7 +26,7 @@
     <button id="pauseBtn">Pause</button>
     <div class="stack">
       <label for="percent">Ir a %:</label>
-      <input id="percent" type="number" min="1" max="100" value="50" style="width:80px" />
+      <input id="percent" type="number" min="1" max="100" value="50" />
       <button id="seekPercentBtn">Ir</button>
     </div>
   </div>
@@ -201,7 +83,7 @@
       </div>
       <div class="flex items-center w-full max-w-xl px-4">
         <span id="barCurrentTime" class="text-sm text-gray-500 w-12 text-center">0:00</span>
-        <input id="barProgress" type="range" min="0" max="100" value="0" class="flex-1 mx-2 h-2 rounded-full appearance-none bg-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500" style="accent-color:#2563eb">
+        <input id="barProgress" type="range" min="0" max="100" value="0" class="flex-1 mx-2 h-2 rounded-full appearance-none bg-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500">
         <span id="barDuration" class="text-sm text-gray-500 w-12 text-center">0:00</span>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- move the inline styles from `wwwroot/index.html` into a dedicated `wwwroot/css/index.css`
- link the new stylesheet from the page and replace inline style attributes with CSS rules

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e094a816e883338e7a7d79581bab42